### PR TITLE
WIP: fix navigation logo when switching to mobile

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -69,8 +69,6 @@ const Header = styled.header`
 `;
 
 const Logo = styled.img`
-  width: 7.375rem;
-
   @media (min-width: ${breakpoint("desktop")}) {
     margin: ${space(0, 4)};
   }


### PR DESCRIPTION
- The big logo that appears in mobile view is gone but it still uses the small log not the big logo 